### PR TITLE
Put _includes dir in first place of JS concat order

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('images-deploy', function() {
 //compiling our Javascripts
 gulp.task('scripts', function() {
     //this is where our dev JS scripts are
-    return gulp.src('app/scripts/src/**/*.js')
+    return gulp.src(['app/scripts/src/_includes/**/*.js', 'app/scripts/src/**/*.js')
                 //this is the filename of the compressed version of our JS
                .pipe(concat('app.js'))
                //catch errors

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('images-deploy', function() {
 //compiling our Javascripts
 gulp.task('scripts', function() {
     //this is where our dev JS scripts are
-    return gulp.src(['app/scripts/src/_includes/**/*.js', 'app/scripts/src/**/*.js')
+    return gulp.src(['app/scripts/src/_includes/**/*.js', 'app/scripts/src/**/*.js'])
                 //this is the filename of the compressed version of our JS
                .pipe(concat('app.js'))
                //catch errors


### PR DESCRIPTION
Solves dependency issues, for example something located in app/scripts/src/main.js might try to utilize jQuery (located in app/scripts/src/_includes/jquery.js) which due to concat order couldn't be initialized by then and thus the script fails.