### PR TITLE
Feature/sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .sass-cache
 .DS_Store
+app/styles/styles.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 //initialize all of our variables
-var app, base, concat, directory, gulp, gutil, hostname, path, refresh, sass, uglify, imagemin, minifyCSS, del, browserSync, autoprefixer, gulpSequence, shell;
+var app, base, concat, directory, gulp, gutil, hostname, path, refresh, sass, uglify, imagemin, minifyCSS, del, browserSync, autoprefixer, gulpSequence, shell, sourceMaps;
 
 var autoPrefixBrowserList = ['last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1', 'ios 6', 'android 4'];
 
@@ -10,6 +10,7 @@ gutil       = require('gulp-util');
 concat      = require('gulp-concat');
 uglify      = require('gulp-uglify');
 sass        = require('gulp-sass');
+sourceMaps  = require('gulp-sourcemaps');
 imagemin    = require('gulp-imagemin');
 minifyCSS   = require('gulp-minify-css');
 browserSync = require('browser-sync');
@@ -75,6 +76,8 @@ gulp.task('scripts-deploy', function() {
 gulp.task('styles', function() {
     //the initializer / master SCSS file, which will just be a file that imports everything
     return gulp.src('app/styles/scss/init.scss')
+                //get sourceMaps ready
+                .pipe(sourceMaps.init())
                 //include SCSS and list every "include" folder
                .pipe(sass({
                       errLogToConsole: true,
@@ -90,6 +93,8 @@ gulp.task('styles', function() {
                .on('error', gutil.log)
                //the final filename of our combined css file
                .pipe(concat('styles.css'))
+                //get our sources via sourceMaps
+                .pipe(sourceMaps.write())
                //where to save our final, compressed css file
                .pipe(gulp.dest('app/styles'))
                //notify browserSync to refresh

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-sass": "^1.3.3",
     "gulp-sequence": "^0.3.2",
     "gulp-shell": "^0.4.0",
+    "gulp-sourcemaps": "^1.5.1",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4"
   }


### PR DESCRIPTION
I find this Gulp plugin extremely useful. When inspecting CSS via Chrome Dev tools or the like it tells you in which partials (`_typography.scss` for example) the styles can be found.